### PR TITLE
Fix configurations section of package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,17 +11,24 @@
 
 	"dflags-dmd": ["-wi"],
 
-	"configurations": {
-		"default": "sdlang",
-
-		"sdlang": {
+	"configurations": [
+		{
+			"name": "test",
+			"targetType": "executable",
 			"versions": ["SDLang_TestApp"],
 			"dflags-dmd": ["-ofbin/sdlang"]
 		},
 
-		"unittest": {
+		{
+			"name": "library",
+			"targetType": "library"
+		},
+
+		{
+			"name": "unittest",
+			"targetType": "executable",
 			"versions": ["SDLang_Unittest", "SDLang_Trace"],
 			"dflags-dmd": ["-ofbin/sdlang-unittest", "-debug", "-gc", "-unittest"]
 		}
-	}
+	]
 }


### PR DESCRIPTION
A while ago the structure of the "configurations" section has changed to a list (the `"default"` configuration was a bad idea and was replaced by a `"platforms"` field for each configuration). I've adjusted it accordingly now and maybe you can also make a new version tag, so that the latest version on code.dlang.org also works.

BTW this came up in a [DUB thread](http://forum.rejectedsoftware.com/groups/rejectedsoftware.dub/thread/279/) (BTW#2 I still want to make SDL an alternative (preferred) for package.json, but haven't had the time for this yet)
