### PR TITLE
Remove unneeded "buildOptions" from package config

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,6 @@
 			"targetName": "sdlang-unittest",
 
 			"versions": ["SDLang_Unittest", "SDLang_Trace"],
-			"buildOptions": [
-				"unittests", "debugMode", "debugInfo"
-			],
 			"dflags-dmd": ["-gc"]
 		}
 	]


### PR DESCRIPTION
DUB complains about them:
```
## Warning for package sdlang-d, configuration unittest ##

The following compiler flags have been specified in the package description
file. They are handled by DUB and direct use in packages is discouraged.
Alternatively, you can set the DFLAGS environment variable to pass custom flags
to the compiler, or use one of the suggestions below:

debugMode: Call DUB with --build=debug
debugInfo: Call DUB with --build=debug
unittests: Call DUB with --build=unittest
```