### PR TITLE
Fix line counter for Windows-style line endings. Fixes #28.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 			"targetPath": "bin/",
 			"targetName": "sdlang-unittest",
 
-			"versions": ["SDLang_Unittest", "SDLang_Trace"],
+			"versions": ["sdlangUnittest", "sdlangTrace"],
 			"dflags-dmd": ["-gc"]
 		}
 	]

--- a/src/sdlang/lexer.d
+++ b/src/sdlang/lexer.d
@@ -1992,3 +1992,37 @@ unittest
 	testLex("--\na",  [ Token(symbol!"Ident",loc,Value(null),"a") ]);
 	testLex("#\na",   [ Token(symbol!"Ident",loc,Value(null),"a") ]);
 }
+
+version(sdlangUnittest)
+unittest
+{
+	writeln("lexer: Regression test issue #28...");
+	stdout.flush();
+
+	enum offset = 1; // workaround for an of-by-one error for line numbers
+	testLex("test", [
+		Token(symbol!"Ident", Location("filename", 0, 0, 0), Value(null), "test")
+	], true);
+	testLex("\ntest", [
+		Token(symbol!"EOL", Location("filename", 0, 0, 0), Value(null), "\n"),
+		Token(symbol!"Ident", Location("filename", 1, 0, 1), Value(null), "test")
+	], true);
+	testLex("\rtest", [
+		Token(symbol!"EOL", Location("filename", 0, 0, 0), Value(null), "\r"),
+		Token(symbol!"Ident", Location("filename", 1, 0, 1), Value(null), "test")
+	], true);
+	testLex("\r\ntest", [
+		Token(symbol!"EOL", Location("filename", 0, 0, 0), Value(null), "\r\n"),
+		Token(symbol!"Ident", Location("filename", 1, 0, 2), Value(null), "test")
+	], true);
+	testLex("\r\n\ntest", [
+		Token(symbol!"EOL", Location("filename", 0, 0, 0), Value(null), "\r\n"),
+		Token(symbol!"EOL", Location("filename", 1, 0, 2), Value(null), "\n"),
+		Token(symbol!"Ident", Location("filename", 2, 0, 3), Value(null), "test")
+	], true);
+	testLex("\r\r\ntest", [
+		Token(symbol!"EOL", Location("filename", 0, 0, 0), Value(null), "\r"),
+		Token(symbol!"EOL", Location("filename", 1, 0, 1), Value(null), "\r\n"),
+		Token(symbol!"Ident", Location("filename", 2, 0, 3), Value(null), "test")
+	], true);
+}

--- a/src/sdlang/lexer.d
+++ b/src/sdlang/lexer.d
@@ -1442,7 +1442,7 @@ version(sdlangUnittest)
 	}
 
 	private int numErrors = 0;
-	private void testLex(string file=__FILE__, size_t line=__LINE__)(string source, Token[] expected)
+	private void testLex(string source, Token[] expected, bool test_locations = false, string file=__FILE__, size_t line=__LINE__)
 	{
 		Token[] actual;
 		try
@@ -1457,8 +1457,13 @@ version(sdlangUnittest)
 			stderr.writeln("        ", e.msg);
 			return;
 		}
+
+		bool is_same = actual == expected;
+		if (is_same && test_locations) {
+			is_same = actual.map!(t => t.location).equal(expected.map!(t => t.location));
+		}
 		
-		if(actual != expected)
+		if(!is_same)
 		{
 			numErrors++;
 			stderr.writeln(file, "(", line, "): testLex failed on: ", source);


### PR DESCRIPTION
Not sure if using an `int` return is the most elegant solution, but it seems to work for all combinations.

Also fixes the "unittest" configuration in package.json and fixes the line numbers reported by `testLex`.

BTW, unrelated to this fix, when running "dub test" (on Windows), I'm getting an access violation in `Fiber.state`:
```
object.Error@(0): Access Violation
----------------
0x004BD669 in const(nothrow @property core.thread.Fiber.State function()) core.thread.Fiber.state
0x00488E42 in D15libInputVisitor272__T12InputVisitorTS6sdlang6parser10PullParserTS3std7variant200__T8VariantNE4542722389B3E902D4E76A676A7CBA4 at C:\Users\sludwig\Develop\SDLang-D\..\..\AppData\Roaming\dub\packages\libinputvisitor-1.1.0\libInputVisitor.d(72)
0x00488CB4 in void sdlang.parser.__unittestL527_13() at C:\Users\sludwig\Develop\SDLang-D\src\sdlang\parser.d(534)
0x00489114 in void sdlang.parser.__modtest()
0x004C9E13 in int core.runtime.runModuleUnitTests().__foreachbody1(object.Module
Info*)
```