### PR TITLE
Allow taggedalgebraic 0.11.x

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -10,7 +10,7 @@ importPaths "src"
 
 buildRequirements "allowWarnings"
 
-dependency "taggedalgebraic" version="~>0.10.2"
+dependency "taggedalgebraic" version=">=0.10.2 <0.12.0-0"
 
 // Run with: dub
 // Or with:  dub build && bin/sdlang


### PR DESCRIPTION
I just had to make minor backwards incompatible changes to TaggedAlgebraic that don't affect most projects, but mean that I had to bump the minor dev-version number. Would be great if you could tag a quick new version when this passes.