### PR TITLE
Improved memory safety and purity

### DIFF
--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,7 +1,7 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"taggedalgebraic": "0.10.2",
-		"unit-threaded": "0.6.28"
+		"taggedalgebraic": "0.11.4",
+		"unit-threaded": "0.10.3"
 	}
 }

--- a/src/sdlang/exception.d
+++ b/src/sdlang/exception.d
@@ -15,7 +15,7 @@ import sdlang.util;
 /// Abstract parent class of all SDLang-D defined exceptions.
 abstract class SDLangException : Exception
 {
-	this(string msg, string file = __FILE__, size_t line = __LINE__)
+	this(string msg, string file = __FILE__, size_t line = __LINE__) @nogc @safe pure nothrow
 	{
 		super(msg, file, line);
 	}
@@ -27,13 +27,13 @@ class ParseException : SDLangException
 	Location location;
 	bool hasLocation;
 
-	this(string msg, string file = __FILE__, size_t line = __LINE__)
+	this(string msg, string file = __FILE__, size_t line = __LINE__) @nogc @safe pure nothrow
 	{
 		hasLocation = false;
 		super(msg, file, line);
 	}
 
-	this(Location location, string msg, string file = __FILE__, size_t line = __LINE__)
+	this(Location location, string msg, string file = __FILE__, size_t line = __LINE__) @safe pure
 	{
 		hasLocation = true;
 		super("%s: %s".format(location.toString(), msg), file, line);
@@ -60,7 +60,7 @@ $(LI Writing SDLang where:
 +/
 class ValidationException : SDLangException
 {
-	this(string msg, string file = __FILE__, size_t line = __LINE__)
+	this(string msg, string file = __FILE__, size_t line = __LINE__) @nogc @safe pure nothrow
 	{
 		super(msg, file, line);
 	}
@@ -73,7 +73,7 @@ alias SDLangValidationException = ValidationException;
 /// Thrown when someting is wrong with the provided arguments to a function.
 class ArgumentException : SDLangException
 {
-	this(string msg, string file = __FILE__, size_t line = __LINE__)
+	this(string msg, string file = __FILE__, size_t line = __LINE__) @nogc @safe pure nothrow
 	{
 		super(msg, file, line);
 	}
@@ -84,7 +84,7 @@ abstract class DOMException : SDLangException
 {
 	Tag base; /// The tag searched from
 
-	this(Tag base, string msg, string file = __FILE__, size_t line = __LINE__)
+	this(Tag base, string msg, string file = __FILE__, size_t line = __LINE__) @nogc @safe pure nothrow
 	{
 		this.base = base;
 		super(msg, file, line);
@@ -125,7 +125,7 @@ abstract class DOMException : SDLangException
 /// Thrown by the DOM on empty range and out-of-range conditions.
 class DOMRangeException : DOMException
 {
-	this(Tag base, string msg, string file = __FILE__, size_t line = __LINE__)
+	this(Tag base, string msg, string file = __FILE__, size_t line = __LINE__) @nogc @safe pure nothrow
 	{
 		super(base, msg, file, line);
 	}
@@ -143,7 +143,7 @@ abstract class DOMNotFoundException : DOMException
 {
 	FullName tagName; /// The tag searched for
 
-	this(Tag base, FullName tagName, string msg, string file = __FILE__, size_t line = __LINE__)
+	this(Tag base, FullName tagName, string msg, string file = __FILE__, size_t line = __LINE__) @nogc @safe pure nothrow
 	{
 		this.tagName = tagName;
 		super(base, msg, file, line);
@@ -153,7 +153,7 @@ abstract class DOMNotFoundException : DOMException
 /// Thrown by the DOM's `sdlang.ast.Tag.expectTag`, etc. functions if a Tag isn't found.
 class TagNotFoundException : DOMNotFoundException
 {
-	this(Tag base, FullName tagName, string msg, string file = __FILE__, size_t line = __LINE__)
+	this(Tag base, FullName tagName, string msg, string file = __FILE__, size_t line = __LINE__) @nogc @safe pure nothrow
 	{
 		super(base, tagName, msg, file, line);
 	}
@@ -165,7 +165,7 @@ class ValueNotFoundException : DOMNotFoundException
 	/// Expected type for the not-found value.
 	TypeInfo valueType;
 
-	this(Tag base, FullName tagName, TypeInfo valueType, string msg, string file = __FILE__, size_t line = __LINE__)
+	this(Tag base, FullName tagName, TypeInfo valueType, string msg, string file = __FILE__, size_t line = __LINE__) @nogc @safe pure nothrow
 	{
 		this.valueType = valueType;
 		super(base, tagName, msg, file, line);
@@ -181,7 +181,7 @@ class AttributeNotFoundException : DOMNotFoundException
 	TypeInfo valueType;
 
 	this(Tag base, FullName tagName, FullName attributeName, TypeInfo valueType, string msg,
-		string file = __FILE__, size_t line = __LINE__)
+		string file = __FILE__, size_t line = __LINE__) @nogc @safe pure nothrow
 	{
 		this.valueType = valueType;
 		this.attributeName = attributeName;

--- a/src/sdlang/lexer.d
+++ b/src/sdlang/lexer.d
@@ -25,13 +25,13 @@ import sdlang.util;
 
 alias sdlang.util.startsWith startsWith;
 
-Token[] lexFile(string filename)
+Token[] lexFile(string filename) @trusted
 {
 	auto source = cast(string)read(filename);
 	return lexSource(source, filename);
 }
 
-Token[] lexSource(string source, string filename=null)
+Token[] lexSource(string source, string filename=null) @trusted
 {
 	auto lexer = scoped!Lexer(source, filename);
 	
@@ -46,17 +46,17 @@ Token[] lexSource(string source, string filename=null)
 
 // Kind of a poor-man's yield, but fast.
 // Only to be used inside Lexer.popFront (and Lexer.this).
-private template accept(string symbolName)
+private template accept(string symbolName) 
 {
 	static assert(symbolName != "Value", "Value symbols must also take a value.");
 	enum accept = acceptImpl!(symbolName, "null");
 }
-private template accept(string symbolName, string value)
+private template accept(string symbolName, string value) 
 {
 	static assert(symbolName == "Value", "Only a Value symbol can take a value.");
 	enum accept = acceptImpl!(symbolName, value);
 }
-private template accept(string symbolName, string value, string startLocation, string endLocation)
+private template accept(string symbolName, string value, string startLocation, string endLocation) 
 {
 	static assert(symbolName == "Value", "Only a Value symbol can take a value.");
 	enum accept = ("
@@ -83,6 +83,7 @@ private template acceptImpl(string symbolName, string value)
 		}
 	").replace("\n", "");
 }
+
 
 class Lexer
 {
@@ -121,7 +122,7 @@ class Lexer
 	}
 	private LookaheadTokenInfo lookaheadTokenInfo;
 	
-	this(string source=null, string filename=null)
+	this(string source=null, string filename=null) @trusted
 	{
 		this.filename = filename;
 		this.source = source;
@@ -150,57 +151,57 @@ class Lexer
 		popFront();
 	}
 	
-	@property bool empty()
+	@property bool empty() @safe pure
 	{
 		return _front.symbol == symbol!"EOF";
 	}
 	
 	Token _front;
-	@property Token front()
+	@property Token front() @safe pure nothrow @nogc
 	{
 		return _front;
 	}
 
-	@property bool isEOF()
+	@property bool isEOF() @safe pure
 	{
 		return location.index == source.length && !lookaheadTokenInfo.exists;
 	}
 
-	private void error(string msg)
+	private void error(string msg) @safe pure
 	{
 		error(location, msg);
 	}
 
 	//TODO: Take varargs and use output range sink.
-	private void error(Location loc, string msg)
+	private void error(Location loc, string msg) @safe pure
 	{
 		throw new ParseException(loc, "Error: "~msg);
 	}
 
-	private Token makeToken(string symbolName)()
+	private Token makeToken(string symbolName)() @safe pure
 	{
 		auto tok = Token(symbol!symbolName, tokenStart);
 		tok.data = tokenData;
 		return tok;
 	}
 	
-	private @property string tokenData()
+	private @property string tokenData() @safe pure
 	{
 		return source[ tokenStart.index .. location.index ];
 	}
 	
 	/// Check the lookahead character
-	private bool lookahead(dchar ch)
+	private bool lookahead(dchar ch) @safe pure @nogc nothrow
 	{
 		return hasNextCh && nextCh == ch;
 	}
 
-	private bool lookahead(bool function(dchar) condition)
+	private bool lookahead(bool function(dchar) @safe pure condition) @safe pure
 	{
 		return hasNextCh && condition(nextCh);
 	}
 
-	private static bool isNewline(dchar ch)
+	private static bool isNewline(dchar ch) @safe pure @nogc nothrow
 	{
 		return ch == '\n' || ch == '\r' || ch == lineSep || ch == paraSep;
 	}
@@ -210,7 +211,7 @@ class Lexer
 	///
 	/// Note that there are only single character sequences and the two
 	/// character sequence `\r\n` as used on Windows.
-	private size_t isAtNewline()
+	private size_t isAtNewline() @safe pure
 	{
 		if(ch == '\n' || ch == lineSep || ch == paraSep) return 1;
 		else if(ch == '\r') return lookahead('\n') ? 2 : 1;
@@ -218,7 +219,7 @@ class Lexer
 	}
 
 	/// Is 'ch' a valid base 64 character?
-	private bool isBase64(dchar ch)
+	private bool isBase64(dchar ch) @safe pure
 	{
 		if(ch >= 'A' && ch <= 'Z')
 			return true;
@@ -234,7 +235,7 @@ class Lexer
 	
 	/// Is the current character one that's allowed
 	/// immediately *after* an int/float literal?
-	private bool isEndOfNumber()
+	private bool isEndOfNumber() @safe pure
 	{
 		if(isEOF)
 			return true;
@@ -245,7 +246,7 @@ class Lexer
 	/// Is current character the last one in an ident?
 	private bool isEndOfIdentCached = false;
 	private bool _isEndOfIdent;
-	private bool isEndOfIdent()
+	private bool isEndOfIdent() @safe pure
 	{
 		if(!isEndOfIdentCached)
 		{
@@ -261,7 +262,7 @@ class Lexer
 	}
 
 	/// Is 'ch' a character that's allowed *somewhere* in an identifier?
-	private bool isIdentChar(dchar ch)
+	private bool isIdentChar(dchar ch) @safe pure
 	{
 		if(isAlpha(ch))
 			return true;
@@ -277,7 +278,7 @@ class Lexer
 				ch == '$';
 	}
 
-	private bool isDigit(dchar ch)
+	private bool isDigit(dchar ch) @safe pure
 	{
 		return ch >= '0' && ch <= '9';
 	}
@@ -288,7 +289,7 @@ class Lexer
 		Continue, // Keyword is not matched *yet*
 		Failed,   // Keyword doesn't match
 	}
-	private KeywordResult checkKeyword(dstring keyword32)
+	private KeywordResult checkKeyword(dstring keyword32) @safe pure
 	{
 		// Still within length of keyword
 		if(tokenLength32 < keyword32.length)
@@ -317,7 +318,7 @@ class Lexer
 	enum ErrorOnEOF { No, Yes }
 
 	/// Advance one code point.
-	private void advanceChar(ErrorOnEOF errorOnEOF)
+	private void advanceChar(ErrorOnEOF errorOnEOF) @safe pure
 	{
 		if(auto cnt = isAtNewline())
 		{
@@ -356,13 +357,13 @@ class Lexer
 	}
 
 	/// Advances the specified amount of characters
-	private void advanceChar(size_t count, ErrorOnEOF errorOnEOF)
+	private void advanceChar(size_t count, ErrorOnEOF errorOnEOF) @safe pure
 	{
 		while(count-- > 0)
 			advanceChar(errorOnEOF);
 	}
 
-	void popFront()
+	void popFront() @trusted
 	{
 		// -- Main Lexer -------------
 
@@ -454,7 +455,7 @@ class Lexer
 	}
 
 	/// Lex Ident or Keyword
-	private void lexIdentKeyword()
+	private void lexIdentKeyword() @trusted
 	{
 		assert(isAlpha(ch) || ch == '_');
 		
@@ -522,7 +523,7 @@ class Lexer
 	}
 
 	/// Lex Ident
-	private void lexIdent()
+	private void lexIdent() @trusted
 	{
 		if(tokenLength == 0)
 			assert(isAlpha(ch) || ch == '_');
@@ -534,7 +535,7 @@ class Lexer
 	}
 	
 	/// Lex regular string
-	private void lexRegularString()
+	private void lexRegularString() @trusted
 	{
 		assert(ch == '"');
 
@@ -595,7 +596,7 @@ class Lexer
 	}
 
 	/// Lex raw string
-	private void lexRawString()
+	private void lexRawString() @trusted
 	{
 		assert(ch == '`');
 		
@@ -608,7 +609,7 @@ class Lexer
 	}
 	
 	/// Lex character literal
-	private void lexCharacter()
+	private void lexCharacter() @trusted
 	{
 		assert(ch == '\'');
 		advanceChar(ErrorOnEOF.Yes); // Skip opening single-quote
@@ -642,12 +643,12 @@ class Lexer
 	}
 	
 	/// Lex base64 binary literal
-	private void lexBinary()
+	private void lexBinary() @trusted
 	{
 		assert(ch == '[');
 		advanceChar(ErrorOnEOF.Yes);
 		
-		void eatBase64Whitespace()
+		void eatBase64Whitespace() @safe pure
 		{
 			while(!isEOF && isWhite(ch))
 			{
@@ -669,7 +670,7 @@ class Lexer
 			private bool isInited = false;
 			private int numInputCharsMod4 = 0;
 			
-			@property bool empty()
+			@property bool empty() @safe pure
 			{
 				if(lexer.ch == ']')
 				{
@@ -682,12 +683,12 @@ class Lexer
 				return false;
 			}
 
-			@property dchar front()
+			@property dchar front() @safe pure
 			{
 				return lexer.ch;
 			}
 			
-			void popFront()
+			void popFront() @safe pure
 			{
 				auto lex = lexer;
 
@@ -730,7 +731,7 @@ class Lexer
 		//TODO: Remove this when DMD #9102 is fixed
 		struct OutputBuf
 		{
-			void put(ubyte ch)
+			void put(ubyte ch) @safe pure
 			{
 				outputBuf.put(ch);
 			}
@@ -747,7 +748,7 @@ class Lexer
 		mixin(accept!("Value", "outputBuf.data"));
 	}
 	
-	private BigInt toBigInt(bool isNegative, string absValue)
+	private BigInt toBigInt(bool isNegative, string absValue) @safe pure
 	{
 		auto num = BigInt(absValue);
 		assert(num >= 0);
@@ -760,7 +761,7 @@ class Lexer
 
 	/// Lex [0-9]+, but without emitting a token.
 	/// This is used by the other numeric parsing functions.
-	private string lexNumericFragment()
+	private string lexNumericFragment() @safe pure
 	{
 		if(!isDigit(ch))
 			error("Expected a digit 0-9.");
@@ -776,7 +777,7 @@ class Lexer
 	}
 
 	/// Lex anything that starts with 0-9 or '-'. Ints, floats, dates, etc.
-	private void lexNumeric(LookaheadTokenInfo laTokenInfo = LookaheadTokenInfo.init)
+	private void lexNumeric(LookaheadTokenInfo laTokenInfo = LookaheadTokenInfo.init) @trusted
 	{
 		bool isNegative;
 		string firstFragment;
@@ -874,7 +875,7 @@ class Lexer
 	}
 	
 	/// Lex any floating-point literal (after the initial numeric fragment was lexed)
-	private void lexFloatingPoint(string firstPart)
+	private void lexFloatingPoint(string firstPart) @trusted
 	{
 		assert(ch == '.');
 		advanceChar(ErrorOnEOF.No);
@@ -930,7 +931,7 @@ class Lexer
 			error("Invalid floating point literal.");
 	}
 
-	private Date makeDate(bool isNegative, string yearStr, string monthStr, string dayStr)
+	private Date makeDate(bool isNegative, string yearStr, string monthStr, string dayStr) @safe pure
 	{
 		BigInt biTmp;
 		
@@ -957,7 +958,7 @@ class Lexer
 	private DateTimeFrac makeDateTimeFrac(
 		bool isNegative, Date date, string hourStr, string minuteStr,
 		string secondStr, string millisecondStr
-	)
+	) @safe pure
 	{
 		BigInt biTmp;
 
@@ -1011,7 +1012,7 @@ class Lexer
 		bool isNegative, string dayStr,
 		string hourStr, string minuteStr, string secondStr,
 		string millisecondStr
-	)
+	) @safe pure
 	{
 		BigInt biTmp;
 
@@ -1068,7 +1069,7 @@ class Lexer
 
 	// This has to reproduce some weird corner case behaviors from the
 	// original Java version of SDL. So some of this may seem weird.
-	private Nullable!Duration getTimeZoneOffset(string str)
+	private Nullable!Duration getTimeZoneOffset(string str) @safe pure
 	{
 		if(str.length < 2)
 			return Nullable!Duration(); // Unknown timezone
@@ -1151,7 +1152,7 @@ class Lexer
 	}
 	
 	/// Lex date or datetime (after the initial numeric fragment was lexed)
-	private void lexDate(bool isDateNegative, string yearStr)
+	private void lexDate(bool isDateNegative, string yearStr) @trusted
 	{
 		assert(ch == '/');
 		
@@ -1199,7 +1200,7 @@ class Lexer
 		auto startOfTime = location;
 
 		// Is time negative?
-		bool isTimeNegative = ch == '-';
+		const bool isTimeNegative = ch == '-';
 		if(isTimeNegative)
 			advanceChar(ErrorOnEOF.Yes);
 
@@ -1296,7 +1297,7 @@ class Lexer
 	}
 
 	/// Lex time span (after the initial numeric fragment was lexed)
-	private void lexTimeSpan(bool isNegative, string firstPart)
+	private void lexTimeSpan(bool isNegative, string firstPart) @trusted
 	{
 		assert(ch == ':' || ch == 'd');
 		
@@ -1347,7 +1348,7 @@ class Lexer
 	}
 
 	/// Advances past whitespace and comments
-	private void eatWhite(bool allowComments=true)
+	private void eatWhite(bool allowComments=true) @safe pure
 	{
 		// -- Comment/Whitepace Lexer -------------
 

--- a/src/sdlang/package.d
+++ b/src/sdlang/package.d
@@ -51,8 +51,9 @@ public import sdlang.token     : Value, Token, DateTimeFrac, DateTimeFracUnknown
 public import sdlang.util      : sdlangVersion, Location;
 
 version(sdlangUsingBuiltinTestRunner)
-	void main() {}
-
+{
+	//void main() {}
+}
 version(sdlangCliApp)
 {
 	int main(string[] args)

--- a/src/sdlang/parser.d
+++ b/src/sdlang/parser.d
@@ -16,7 +16,7 @@ import sdlang.token;
 import sdlang.util;
 
 /// Returns root tag.
-Tag parseFile(string filename)
+Tag parseFile(string filename) @trusted
 {
 	auto source = cast(string)read(filename);
 	return parseSource(source, filename);
@@ -25,7 +25,7 @@ Tag parseFile(string filename)
 /// Returns root tag. The optional `filename` parameter can be included
 /// so that the SDLang document's filename (if any) can be displayed with
 /// any syntax error messages.
-Tag parseSource(string source, string filename=null)
+Tag parseSource(string source, string filename=null) @trusted
 {
 	auto lexer = new Lexer(source, filename);
 	auto parser = DOMParser(lexer);
@@ -77,14 +77,14 @@ TagStartEvent (lastTag)
 TagEndEvent
 ------------------
 +/
-auto pullParseFile(string filename)
+auto pullParseFile(string filename) @trusted
 {
 	auto source = cast(string)read(filename);
 	return parseSource(source, filename);
 }
 
 ///ditto
-auto pullParseSource(string source, string filename=null)
+auto pullParseSource(string source, string filename=null) @trusted
 {
 	auto lexer = new Lexer(source, filename);
 	auto parser = PullParser(lexer);
@@ -247,23 +247,23 @@ private struct PullParser
 		string name;
 	}
 	
-	private void error(string msg)
+	private void error(string msg) @safe pure
 	{
 		error(lexer.front.location, msg);
 	}
 
-	private void error(Location loc, string msg)
+	private void error(Location loc, string msg) @safe pure
 	{
 		throw new ParseException(loc, "Error: "~msg);
 	}
 	
-	private void emit(Event)(Event event)
+	private void emit(Event)(Event event) @trusted
 	{
 		yield( ParserEvent(event) );
 	}
 	
 	/// <Root> ::= <Tags> EOF  (Lookaheads: Anything)
-	private void parseRoot()
+	private void parseRoot() @trusted
 	{
 		//trace("Starting parse of file: ", lexer.filename);
 		//trace(__FUNCTION__, ": <Root> ::= <Tags> EOF  (Lookaheads: Anything)");
@@ -295,7 +295,7 @@ private struct PullParser
 	/// <Tags> ::= <Tag> <Tags>  (Lookaheads: Ident Value)
 	///        |   EOL   <Tags>  (Lookaheads: EOL)
 	///        |   {empty}       (Lookaheads: Anything else, except '{')
-	void parseTags()
+	void parseTags() @safe
 	{
 		//trace("Enter ", __FUNCTION__);
 		while(true)
@@ -329,7 +329,7 @@ private struct PullParser
 	/// <Tag>
 	///     ::= <IDFull> <Values> <Attributes> <OptChild> <TagTerminator>  (Lookaheads: Ident)
 	///     |   <Value>  <Values> <Attributes> <OptChild> <TagTerminator>  (Lookaheads: Value)
-	void parseTag()
+	void parseTag() @safe
 	{
 		auto token = lexer.front;
 		if(token.matches!"Ident"())
@@ -361,7 +361,7 @@ private struct PullParser
 	}
 
 	/// <IDFull> ::= Ident <IDSuffix>  (Lookaheads: Ident)
-	IDFull parseIDFull()
+	IDFull parseIDFull() @safe
 	{
 		auto token = lexer.front;
 		if(token.matches!"Ident"())
@@ -380,7 +380,7 @@ private struct PullParser
 	/// <IDSuffix>
 	///     ::= ':' Ident  (Lookaheads: ':')
 	///     ::= {empty}    (Lookaheads: Anything else)
-	IDFull parseIDSuffix(string firstIdent)
+	IDFull parseIDSuffix(string firstIdent) @trusted
 	{
 		auto token = lexer.front;
 		if(token.matches!":"())
@@ -409,7 +409,7 @@ private struct PullParser
 	/// <Values>
 	///     ::= Value <Values>  (Lookaheads: Value)
 	///     |   {empty}         (Lookaheads: Anything else)
-	void parseValues()
+	void parseValues() @safe
 	{
 		while(true)
 		{
@@ -429,7 +429,7 @@ private struct PullParser
 	}
 
 	/// Handle Value terminals that aren't part of an attribute
-	void parseValue()
+	void parseValue() @safe
 	{
 		auto token = lexer.front;
 		if(token.matches!"Value"())
@@ -448,7 +448,7 @@ private struct PullParser
 	/// <Attributes>
 	///     ::= <Attribute> <Attributes>  (Lookaheads: Ident)
 	///     |   {empty}                   (Lookaheads: Anything else)
-	void parseAttributes()
+	void parseAttributes() @safe
 	{
 		while(true)
 		{
@@ -468,7 +468,7 @@ private struct PullParser
 	}
 
 	/// <Attribute> ::= <IDFull> '=' Value  (Lookaheads: Ident)
-	void parseAttribute()
+	void parseAttribute() @trusted
 	{
 		//trace(__FUNCTION__, ": <Attribute> ::= <IDFull> '=' Value  (Lookaheads: Ident)");
 		auto token = lexer.front;
@@ -495,7 +495,7 @@ private struct PullParser
 	/// <OptChild>
 	///      ::= '{' EOL <Tags> '}'  (Lookaheads: '{')
 	///      |   {empty}             (Lookaheads: Anything else)
-	void parseOptChild()
+	void parseOptChild() @trusted
 	{
 		auto token = lexer.front;
 		if(token.matches!"{")
@@ -524,7 +524,7 @@ private struct PullParser
 	/// <TagTerminator>
 	///     ::= EOL      (Lookahead: EOL)
 	///     |   {empty}  (Lookahead: EOF)
-	void parseTagTerminator()
+	void parseTagTerminator() @safe
 	{
 		auto token = lexer.front;
 		if(token.matches!"EOL")
@@ -546,7 +546,7 @@ private struct DOMParser
 {
 	Lexer lexer;
 	
-	Tag parseRoot()
+	Tag parseRoot() @trusted
 	{
 		auto currTag = new Tag(null, null, "root");
 		currTag.location = Location(lexer.filename, 0, 0, 0);

--- a/src/sdlang/symbol.d
+++ b/src/sdlang/symbol.d
@@ -27,7 +27,7 @@ template symbol(string name)
 	immutable symbol = _symbol(name);
 }
 
-private Symbol _symbol(string name)
+private Symbol _symbol(string name) @safe pure
 {
 	return Symbol(name);
 }
@@ -43,18 +43,18 @@ private Symbol _symbol(string name)
 struct Symbol
 {
 	private string _name;
-	@property string name()
+	@property string name() @safe pure @nogc nothrow
 	{
 		return _name;
 	}
 	
 	@disable this();
-	private this(string name)
+	private this(string name) @safe pure @nogc nothrow
 	{
 		this._name = name;
 	}
 
-	string toString()
+	string toString() @safe pure @nogc nothrow
 	{
 		return _name;
 	}

--- a/src/sdlang/token.d
+++ b/src/sdlang/token.d
@@ -50,11 +50,11 @@ struct DateTimeFracUnknownZone
 	}
 	string timeZone;
 
-	bool opEquals(const DateTimeFracUnknownZone b) const
+	bool opEquals(const DateTimeFracUnknownZone b) const @safe pure
 	{
 		return opEquals(b);
 	}
-	bool opEquals(ref const DateTimeFracUnknownZone b) const
+	bool opEquals(ref const DateTimeFracUnknownZone b) const @safe pure
 	{
 		return
 			this.dateTime == b.dateTime &&
@@ -104,7 +104,8 @@ enum isSink(T) =
 	isOutputRange!T &&
 	is(ElementType!(T)[] == string);
 
-string toSDLString(T)(T value) if(is(T==Value) || isValueType!T)
+string toSDLString(T)(T value) @trusted
+	if(is(T==Value) || isValueType!T) 
 {
 	Appender!string sink;
 	toSDLString(value, sink);
@@ -113,7 +114,8 @@ string toSDLString(T)(T value) if(is(T==Value) || isValueType!T)
 
 /// Throws SDLangException if value is infinity, -infinity or NaN, because
 /// those are not currently supported by the SDLang spec.
-void toSDLString(Sink)(Value value, ref Sink sink) if(isOutputRange!(Sink,char))
+void toSDLString(Sink)(Value value, ref Sink sink) @trusted 
+	if(isOutputRange!(Sink,char))
 {
 	foreach(T; ValueTypes)
 	{
@@ -173,18 +175,21 @@ unittest
 	assertThrown!ValidationException( toSDLString(Value(realNaN)) );
 }
 
-void toSDLString(Sink)(typeof(null) value, ref Sink sink) if(isOutputRange!(Sink,char))
+void toSDLString(Sink)(typeof(null) value, ref Sink sink) @safe pure
+		if(isOutputRange!(Sink,char))
 {
 	sink.put("null");
 }
 
-void toSDLString(Sink)(bool value, ref Sink sink) if(isOutputRange!(Sink,char))
+void toSDLString(Sink)(bool value, ref Sink sink) @safe pure
+		if(isOutputRange!(Sink,char))
 {
 	sink.put(value? "true" : "false");
 }
 
 //TODO: Figure out how to properly handle strings/chars containing lineSep or paraSep
-void toSDLString(Sink)(string value, ref Sink sink) if(isOutputRange!(Sink,char))
+void toSDLString(Sink)(string value, ref Sink sink) @safe pure
+		if(isOutputRange!(Sink,char))
 {
 	sink.put('"');
 	
@@ -203,7 +208,8 @@ void toSDLString(Sink)(string value, ref Sink sink) if(isOutputRange!(Sink,char)
 	sink.put('"');
 }
 
-void toSDLString(Sink)(dchar value, ref Sink sink) if(isOutputRange!(Sink,char))
+void toSDLString(Sink)(dchar value, ref Sink sink) @safe pure
+		if(isOutputRange!(Sink,char))
 {
 	sink.put('\'');
 	
@@ -218,17 +224,20 @@ void toSDLString(Sink)(dchar value, ref Sink sink) if(isOutputRange!(Sink,char))
 	sink.put('\'');
 }
 
-void toSDLString(Sink)(int value, ref Sink sink) if(isOutputRange!(Sink,char))
+void toSDLString(Sink)(int value, ref Sink sink) @safe pure
+		if(isOutputRange!(Sink,char))
 {
 	sink.put( "%s".format(value) );
 }
 
-void toSDLString(Sink)(long value, ref Sink sink) if(isOutputRange!(Sink,char))
+void toSDLString(Sink)(long value, ref Sink sink) @safe pure
+		if(isOutputRange!(Sink,char))
 {
 	sink.put( "%sL".format(value) );
 }
 
-private void checkUnsupportedFloatingPoint(T)(T value) if(isFloatingPoint!T)
+private void checkUnsupportedFloatingPoint(T)(T value) @safe pure
+		if(isFloatingPoint!T)
 {
 	import std.exception;
 	import std.math;
@@ -244,14 +253,15 @@ private void checkUnsupportedFloatingPoint(T)(T value) if(isFloatingPoint!T)
 	);
 }
 
-private string trimmedDecimal(string str)
+private string trimmedDecimal(string str) @safe pure
 {
 	Appender!string sink;
 	trimmedDecimal(str, sink);
 	return sink.data;
 }
 
-private void trimmedDecimal(Sink)(string str, ref Sink sink) if(isOutputRange!(Sink,char))
+private void trimmedDecimal(Sink)(string str, ref Sink sink) @safe pure
+		if(isOutputRange!(Sink,char))
 {
 	// Special case
 	if(str == ".")
@@ -295,21 +305,24 @@ unittest
 	assert(trimmedDecimal(".")          == "0");
 }
 
-void toSDLString(Sink)(float value, ref Sink sink) if(isOutputRange!(Sink,char))
+void toSDLString(Sink)(float value, ref Sink sink) @safe
+		if(isOutputRange!(Sink,char))
 {
 	checkUnsupportedFloatingPoint(value);
 	"%.10f".format(value).trimmedDecimal(sink);
 	sink.put("F");
 }
 
-void toSDLString(Sink)(double value, ref Sink sink) if(isOutputRange!(Sink,char))
+void toSDLString(Sink)(double value, ref Sink sink) @safe
+		if(isOutputRange!(Sink,char))
 {
 	checkUnsupportedFloatingPoint(value);
 	"%.30f".format(value).trimmedDecimal(sink);
 	sink.put("D");
 }
 
-void toSDLString(Sink)(real value, ref Sink sink) if(isOutputRange!(Sink,char))
+void toSDLString(Sink)(real value, ref Sink sink) @safe
+		if(isOutputRange!(Sink,char))
 {
 	checkUnsupportedFloatingPoint(value);
 	"%.90f".format(value).trimmedDecimal(sink);
@@ -342,7 +355,8 @@ unittest
 	assert(!tag.values[2].toSDLString.canFind("-"));
 }
 
-void toSDLString(Sink)(Date value, ref Sink sink) if(isOutputRange!(Sink,char))
+void toSDLString(Sink)(Date value, ref Sink sink) @safe pure
+		if(isOutputRange!(Sink,char))
 {
 	sink.put(to!string(value.year));
 	sink.put('/');
@@ -351,7 +365,8 @@ void toSDLString(Sink)(Date value, ref Sink sink) if(isOutputRange!(Sink,char))
 	sink.put(to!string(value.day));
 }
 
-void toSDLString(Sink)(DateTimeFrac value, ref Sink sink) if(isOutputRange!(Sink,char))
+void toSDLString(Sink)(DateTimeFrac value, ref Sink sink) @safe pure
+		if(isOutputRange!(Sink,char))
 {
 	toSDLString(value.dateTime.date, sink);
 	sink.put(' ');
@@ -372,7 +387,8 @@ void toSDLString(Sink)(DateTimeFrac value, ref Sink sink) if(isOutputRange!(Sink
 	}
 }
 
-void toSDLString(Sink)(SysTime value, ref Sink sink) if(isOutputRange!(Sink,char))
+void toSDLString(Sink)(SysTime value, ref Sink sink)  @safe
+		if(isOutputRange!(Sink,char))
 {
 	auto dateTimeFrac = DateTimeFrac(cast(DateTime)value, value.fracSecs);
 	toSDLString(dateTimeFrac, sink);
@@ -417,7 +433,8 @@ void toSDLString(Sink)(SysTime value, ref Sink sink) if(isOutputRange!(Sink,char
 		sink.put(tzString);
 }
 
-void toSDLString(Sink)(DateTimeFracUnknownZone value, ref Sink sink) if(isOutputRange!(Sink,char))
+void toSDLString(Sink)(DateTimeFracUnknownZone value, ref Sink sink) @safe pure
+		if(isOutputRange!(Sink,char))
 {
 	auto dateTimeFrac = DateTimeFrac(value.dateTime, value.fracSecs);
 	toSDLString(dateTimeFrac, sink);
@@ -426,7 +443,8 @@ void toSDLString(Sink)(DateTimeFracUnknownZone value, ref Sink sink) if(isOutput
 	sink.put(value.timeZone);
 }
 
-void toSDLString(Sink)(Duration value, ref Sink sink) if(isOutputRange!(Sink,char))
+void toSDLString(Sink)(Duration value, ref Sink sink) @safe pure
+		if(isOutputRange!(Sink,char))
 {
 	if(value < seconds(0))
 	{
@@ -454,7 +472,8 @@ void toSDLString(Sink)(Duration value, ref Sink sink) if(isOutputRange!(Sink,cha
 	}
 }
 
-void toSDLString(Sink)(ubyte[] value, ref Sink sink) if(isOutputRange!(Sink,char))
+void toSDLString(Sink)(ubyte[] value, ref Sink sink) @safe pure
+		if(isOutputRange!(Sink,char)) 
 {
 	sink.put('[');
 	sink.put( Base64.encode(value) );
@@ -471,7 +490,7 @@ struct Token
 	string data; /// Original text from source
 
 	@disable this();
-	this(Symbol symbol, Location location, Value value=Value(null), string data=null)
+	this(Symbol symbol, Location location, Value value=Value(null), string data=null) @safe pure @nogc nothrow
 	{
 		this.symbol   = symbol;
 		this.location = location;
@@ -484,11 +503,11 @@ struct Token
 	/// Tokens with differing Value types are always unequal.
 	/// Member `location` is always ignored for comparison.
 	/// Member `data` is ignored for comparison *EXCEPT* when the symbol is Ident.
-	bool opEquals(Token b)
+	bool opEquals(Token b) @safe
 	{
 		return opEquals(b);
 	}
-	bool opEquals(ref Token b) ///ditto
+	bool opEquals(ref Token b) @trusted ///ditto
 	{
 		if(
 			this.symbol     != b.symbol     ||
@@ -503,10 +522,11 @@ struct Token
 		return true;
 	}
 	
-	bool matches(string symbolName)()
+	bool matches(string symbolName)() @safe pure
 	{
 		return this.symbol == .symbol!symbolName;
 	}
+	//TODO: override opAssign to improve memory safety and purity
 }
 
 @("sdlang token")

--- a/src/sdlang/util.d
+++ b/src/sdlang/util.d
@@ -30,15 +30,15 @@ struct Location
 	int line; /// Zero-indexed
 	int col;  /// Zero-indexed, Tab counts as 1
 	size_t index; /// Index into the source
-
-	this(int line, int col, int index)
+	///Ctor
+	this(int line, int col, int index) @nogc @safe pure nothrow
 	{
 		this.line  = line;
 		this.col   = col;
 		this.index = index;
 	}
-
-	this(string file, int line, int col, int index)
+	///Ditto
+	this(string file, int line, int col, int index) @nogc @safe pure nothrow
 	{
 		this.file  = file;
 		this.line  = line;
@@ -47,7 +47,7 @@ struct Location
 	}
 
 	/// Convert to string. Optionally takes output range as a sink.
-	string toString()
+	string toString() @safe pure 
 	{
 		Appender!string sink;
 		this.toString(sink);
@@ -55,7 +55,8 @@ struct Location
 	}
 
 	///ditto
-	void toString(Sink)(ref Sink sink) if(isOutputRange!(Sink,char))
+	void toString(Sink)(ref Sink sink) @safe pure 
+			if(isOutputRange!(Sink,char)) 
 	{
 		sink.put(file);
 		sink.put("(");
@@ -65,14 +66,16 @@ struct Location
 		sink.put(")");
 	}
 }
-
+/**
+ * Implements the full name of a tag or attribute.
+ */
 struct FullName
 {
-	string namespace;
-	string name;
+	string namespace;		///Namespace part of the full name
+	string name;			///Name part of the full name
 
 	/// Convert to string. Optionally takes output range as a sink.
-	string toString()
+	string toString() @safe pure
 	{
 		if(namespace == "")
 			return name;
@@ -83,7 +86,8 @@ struct FullName
 	}
 
 	///ditto
-	void toString(Sink)(ref Sink sink) if(isOutputRange!(Sink,char))
+	void toString(Sink)(ref Sink sink) @safe pure 
+		if(isOutputRange!(Sink,char))
 	{
 		if(namespace != "")
 		{
@@ -94,8 +98,8 @@ struct FullName
 		sink.put(name);
 	}
 
-	///
-	static string combine(string namespace, string name)
+	///Combines the namespace and name into a full SDL name
+	static string combine(string namespace, string name) @safe pure
 	{
 		return FullName(namespace, name).toString();
 	}
@@ -108,8 +112,8 @@ struct FullName
 		assert(FullName.combine("namespace", "name") == "namespace:name");
 	}
 
-	///
-	static FullName parse(string fullName)
+	///Parses a name from a string
+	static FullName parse(string fullName) @safe pure
 	{
 		FullName result;
 		
@@ -138,7 +142,7 @@ struct FullName
 
 	/// Throws with appropriate message if this.name is "*".
 	/// Wildcards are only supported for namespaces, not names.
-	void ensureNoWildcardName(string extaMsg = null)
+	void ensureNoWildcardName(string extaMsg = null) @safe pure
 	{
 		if(name == "*")
 			throw new ArgumentException(`Wildcards ("*") only allowed for namespaces, not names. `~extaMsg);


### PR DESCRIPTION
I could only perform the internal unittest (unit-threaded couldn't be used due to a function wasn't exported properly), and it has issues with certain floating-point numbers in the lexer's unittest. I'll look into that in the future, as well as adding the feature of getting tags by path.

Also note that thanks to some dependencies being left behind by the D community, I couldn't put `pure` everywhere it was possible, and instead of `@safe` I had to rely on `@trusted`.