### PR TITLE
Remove FracSec usage if not available in Phobos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,10 @@ script: ./ci_script
 
 matrix:
     include:
-        - d: dmd-2.084.1
+        - d: dmd-2.091.0
           env: DUB_UPGRADE=true   # Test with latest supported dependencies
+        - d: dmd-2.091.0
+          env: DUB_SELECT=ut-0.7.46
         - d: dmd-2.084.1
           env: DUB_SELECT=ut-0.7.46
         - d: dmd-2.083.1
@@ -61,7 +63,7 @@ matrix:
         - d: gdc-4.8.5
 
         # on Mac just test latest & oldest supported dmd and ldc
-        - d: dmd-2.081.1
+        - d: dmd-2.091.0
           env: DUB_SELECT=ut-0.7.46
           os: osx
           osx_image: xcode9 # use OSX 10.13

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,12 @@ platform: x64
 environment:
  matrix:
   - DC: dmd
+    DVersion: 2.091.0
+    arch: x86
+  - DC: dmd
+    DVersion: 2.091.0
+    arch: x64
+  - DC: dmd
     DVersion: 2.084.1
     arch: x86
   - DC: dmd

--- a/src/sdlang/token.d
+++ b/src/sdlang/token.d
@@ -24,9 +24,11 @@ struct DateTimeFrac
 {
 	DateTime dateTime;
 	Duration fracSecs;
-	deprecated("Use fracSecs instead.") {
+	static if(is(FracSec)) {
+	    deprecated("Use fracSecs instead.") {
 		@property FracSec fracSec() const { return FracSec.from!"hnsecs"(fracSecs.total!"hnsecs"); }
 		@property void fracSec(FracSec v) { fracSecs = v.hnsecs.hnsecs; }
+	    }
 	}
 }
 
@@ -44,9 +46,11 @@ struct DateTimeFracUnknownZone
 {
 	DateTime dateTime;
 	Duration fracSecs;
-	deprecated("Use fracSecs instead.") {
+	static if(is(FracSec)) {
+	    deprecated("Use fracSecs instead.") {
 		@property FracSec fracSec() const { return FracSec.from!"hnsecs"(fracSecs.total!"hnsecs"); }
 		@property void fracSec(FracSec v) { fracSecs = v.hnsecs.hnsecs; }
+	    }
 	}
 	string timeZone;
 


### PR DESCRIPTION
Fixes #68 

Kind of a punt at this point, just do a static test and don't define the conversion methods if the type is gone.

I'm not clear if this warrants a major or even minor revision change, as it's still the same API if you use a previous compiler.