### PR TITLE
Make lexer emit token ranges instead of just locations

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -41,7 +41,7 @@ configuration "unittest" {
 	targetName "sdlang-unittest"
 	buildOptions "unittests"  // DUB Issue #950
 
-	dependency "unit-threaded" version=">=0.6.28 <0.8.0-0"
+	dependency "unit-threaded" version="~>2.0"
 
 	preBuildCommands "dub run unit-threaded -c gen_ut_main -- -f bin/ut.d"
 

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,7 +1,7 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"taggedalgebraic": "0.10.2",
-		"unit-threaded": "0.6.28"
+		"taggedalgebraic": "0.11.22",
+		"unit-threaded": "2.1.6"
 	}
 }

--- a/src/sdlang/exception.d
+++ b/src/sdlang/exception.d
@@ -24,19 +24,29 @@ abstract class SDLangException : Exception
 /// Thrown when a syntax error is encounterd while parsing.
 class ParseException : SDLangException
 {
-	Location location;
-	bool hasLocation;
+	Location[2] range;
 
 	this(string msg, string file = __FILE__, size_t line = __LINE__)
 	{
-		hasLocation = false;
 		super(msg, file, line);
 	}
 
+	deprecated("Use the overload with a Location[2] range instead")
 	this(Location location, string msg, string file = __FILE__, size_t line = __LINE__)
 	{
-		hasLocation = true;
 		super("%s: %s".format(location.toString(), msg), file, line);
+		range[] = location;
+	}
+
+	this(Location[2] range, string msg, string file = __FILE__, size_t line = __LINE__)
+	{
+		super("%s: %s".format(range.toString(), msg), file, line);
+		this.range = range;
+	}
+
+	bool hasLocation() const pure nothrow @safe @nogc scope
+	{
+		return range[0] !is Location.init || range[1] !is Location.init;
 	}
 }
 
@@ -107,7 +117,7 @@ abstract class DOMException : SDLangException
 	{
 		if(base)
 		{
-			sink.put(base.location.toString());
+			sink.put(base.nameRange.toString());
 			sink.put(": ");
 			sink.put(msg);
 		}

--- a/src/sdlang/package.d
+++ b/src/sdlang/package.d
@@ -108,7 +108,7 @@ version(sdlangCliApp)
 			
 			// Display
 			writeln(
-				tok.location.toString, ":\t",
+				tok.range.toString, ":\t",
 				tok.symbol.name, value,
 				data
 			);

--- a/src/sdlang/token.d
+++ b/src/sdlang/token.d
@@ -1,4 +1,4 @@
-﻿// SDLang-D
+// SDLang-D
 // Written in the D programming language.
 
 module sdlang.token;
@@ -501,7 +501,8 @@ struct Token
 		)
 			return false;
 		
-		if(this.symbol == .symbol!"Ident")
+		if(this.symbol == .symbol!"Ident"
+			|| this.symbol == .symbol!"EOL")
 			return this.data == b.data;
 		
 		return true;

--- a/src/sdlang/util.d
+++ b/src/sdlang/util.d
@@ -61,9 +61,42 @@ struct Location
 		sink.put("(");
 		sink.put(to!string(line+1));
 		sink.put(":");
-		sink.put(to!string(col+1));
+		sink.put(to!string(col));
 		sink.put(")");
 	}
+
+	string toRawString()
+	{
+		return format!"Location(`%s`, line=%s, col=%s, i=%s)"(file, line, col, index);
+	}
+}
+
+string toString(scope const Location[2] range) pure @safe nothrow
+{
+	assert(range[0].file == range[1].file);
+	Appender!string sink;
+	sink.put(range[0].file);
+	sink.put("(");
+	sink.put(to!string(range[0].line+1));
+	sink.put(":");
+	sink.put(to!string(range[0].col));
+	if (range[0].line == range[1].line)
+	{
+		if (range[0].col != range[1].col)
+		{
+			sink.put("..");
+			sink.put(to!string(range[1].col+1));
+		}
+	}
+	else
+	{
+		sink.put("-");
+		sink.put(to!string(range[1].line+1));
+		sink.put(":");
+		sink.put(to!string(range[1].col+1));
+	}
+	sink.put(")");
+	return sink.data;
 }
 
 struct FullName


### PR DESCRIPTION
With this we can more easily check for whitespace and comments between
tokens, without needing a large overhaul of the lexer range.

Helps tools being able to retain comments and even whitespace when
inserting content, since they are able to slice the input.

Additionally error messages are more accurate / with length with this.